### PR TITLE
add a spinning art cover toggle

### DIFF
--- a/plugins/radiant-lyrics-luna/src/Settings.tsx
+++ b/plugins/radiant-lyrics-luna/src/Settings.tsx
@@ -8,6 +8,7 @@ export const settings = await ReactiveStore.getPluginStorage("RadiantLyrics", {
 	lyricsGlowEnabled: true,
 	spinningCoverEverywhere: false,
 	performanceMode: false,
+	noSpinningArt: false,
 	backgroundContrast: 120,
 	backgroundBlur: 80,
 	backgroundBrightness: 40,
@@ -21,6 +22,7 @@ export const Settings = () => {
 	const [lyricsGlowEnabled, setLyricsGlowEnabled] = React.useState(settings.lyricsGlowEnabled);
 	const [spinningCoverEverywhere, setSpinningCoverEverywhere] = React.useState(settings.spinningCoverEverywhere);
 	const [performanceMode, setPerformanceMode] = React.useState(settings.performanceMode);
+	const [noSpinningArt, setNoSpinningArt] = React.useState(settings.noSpinningArt);
 	const [backgroundContrast, setBackgroundContrast] = React.useState(settings.backgroundContrast);
 	const [backgroundBlur, setBackgroundBlur] = React.useState(settings.backgroundBlur);
 	const [backgroundBrightness, setBackgroundBrightness] = React.useState(settings.backgroundBrightness);
@@ -87,6 +89,21 @@ export const Settings = () => {
 						(window as any).updateRadiantLyricsGlobalBackground();
 					}
 					if ((window as any).updateRadiantLyricsNowPlayingBackground) {
+						(window as any).updateRadiantLyricsNowPlayingBackground();
+					}
+				}}
+			/>
+			<LunaSwitchSetting
+				title="Disable Spinning Art"
+				desc="Disable the spinning cover art background animation"
+				checked={noSpinningArt}
+				onChange={(_, checked: boolean) => {
+					console.log("No Spinning Art:", checked ? "enabled" : "disabled");
+					setNoSpinningArt((settings.noSpinningArt = checked));
+					if ((window as any).updateRadiantLyricsGlobalBackground) {
+						(window as any).updateRadiantLyricsGlobalBackground();
+					}
+					if (settings.settingsAffectNowPlaying && (window as any).updateRadiantLyricsNowPlayingBackground) {
 						(window as any).updateRadiantLyricsNowPlayingBackground();
 					}
 				}}

--- a/plugins/radiant-lyrics-luna/src/index.ts
+++ b/plugins/radiant-lyrics-luna/src/index.ts
@@ -202,7 +202,12 @@ const applyGlobalSpinningBackground = (coverArtImageSrc: string): void => {
             globalBackgroundImage.style.width = '120vw';
             globalBackgroundImage.style.height = '120vh';
             globalBackgroundImage.style.filter = `blur(${Math.min(settings.backgroundBlur, 20)}px) brightness(${settings.backgroundBrightness / 100}) contrast(${Math.min(settings.backgroundContrast, 150)}%)`;
-            globalBackgroundImage.style.animation = `spinGlobal ${settings.spinSpeed}s linear infinite`;
+            if (!settings.noSpinningArt) {
+                globalBackgroundImage.style.animation = `spinGlobal ${settings.spinSpeed}s linear infinite`;
+            }
+            else {
+                globalBackgroundImage.style.animation = 'none';
+            }
             globalBackgroundImage.classList.remove('performance-mode-static');
             globalBackgroundImage.style.willChange = 'transform';
         } else {
@@ -210,7 +215,12 @@ const applyGlobalSpinningBackground = (coverArtImageSrc: string): void => {
             globalBackgroundImage.style.width = '150vw';
             globalBackgroundImage.style.height = '150vh';
             globalBackgroundImage.style.filter = `blur(${settings.backgroundBlur}px) brightness(${settings.backgroundBrightness / 100}) contrast(${settings.backgroundContrast}%)`;
-            globalBackgroundImage.style.animation = `spinGlobal ${settings.spinSpeed}s linear infinite`;
+            if (!settings.noSpinningArt) {
+                globalBackgroundImage.style.animation = `spinGlobal ${settings.spinSpeed}s linear infinite`;
+            }
+            else {
+                globalBackgroundImage.style.animation = 'none';
+            }
             globalBackgroundImage.classList.remove('performance-mode-static');
             globalBackgroundImage.style.willChange = 'transform';
         }
@@ -281,11 +291,21 @@ const updateRadiantLyricsNowPlayingBackground = function(): void {
             // Reduce blur and effects for better performance, but keep spinning
             blur = Math.min(blur, 20);
             contrast = Math.min(contrast, 150);
+            if (!settings.noSpinningArt) {
             imgElement.style.animation = `spin ${spinSpeed}s linear infinite`;
+            }
+            else {
+                imgElement.style.animation = 'none';
+            }
             imgElement.classList.remove('performance-mode-static');
             imgElement.style.willChange = 'transform';
         } else {
+            if (!settings.noSpinningArt) {
             imgElement.style.animation = `spin ${spinSpeed}s linear infinite`;
+            }
+            else {
+                imgElement.style.animation = 'none';
+            }
             imgElement.classList.remove('performance-mode-static');
             imgElement.style.willChange = 'transform';
         }


### PR DESCRIPTION
had a typo in the commit message. still a valid change as i like your background cover art implementation the most but im still missing the option to disable spinning art cover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Disable Spinning Art" switch in the settings panel, allowing users to turn off spinning cover art background animations.

- **Bug Fixes**
  - Background and Now Playing cover art animations now immediately update when the "Disable Spinning Art" setting is toggled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->