### PR TITLE
HideUI Now hides header bar (Minimize, Fullscreen & Search)

### DIFF
--- a/plugins/obsidian-theme-luna/src/dark-theme.css
+++ b/plugins/obsidian-theme-luna/src/dark-theme.css
@@ -12,7 +12,7 @@
 [class*="_coverImage_"],
 [class*="_overlayIconWrapperAlbum_"],
 [class*="_playButton_"] {
-	border-radius: 10px !important;
+	border-radius: 5px !important;
 }
 
 ::-webkit-scrollbar {

--- a/plugins/obsidian-theme-luna/src/light-theme.css
+++ b/plugins/obsidian-theme-luna/src/light-theme.css
@@ -12,7 +12,7 @@
 [class*="_coverImage_"],
 [class*="_overlayIconWrapperAlbum_"],
 [class*="_playButton_"] {
-	border-radius: 10px !important;
+	border-radius: 5px !important;
 }
 
 ::-webkit-scrollbar {

--- a/plugins/obsidian-theme-luna/src/oled-friendly.css
+++ b/plugins/obsidian-theme-luna/src/oled-friendly.css
@@ -12,7 +12,7 @@
 [class*="_coverImage_"],
 [class*="_overlayIconWrapperAlbum_"],
 [class*="_playButton_"] {
-	border-radius: 10px !important;
+	border-radius: 5px !important;
 }
 
 ::-webkit-scrollbar {

--- a/plugins/radiant-lyrics-luna/src/styles.css
+++ b/plugins/radiant-lyrics-luna/src/styles.css
@@ -14,7 +14,7 @@
 [class*="_coverImage_"],
 [class*="_overlayIconWrapperAlbum_"],
 [class*="_playButton_"] {
-	border-radius: 10px !important;
+	border-radius: 5px !important;
 }
 
 /* Only apply styles when UI is hidden */
@@ -30,7 +30,8 @@
 /* Hide header container (search, minimize, fullscreen) when UI is hidden */
 .radiant-lyrics-ui-hidden [data-test="header-container"] {
 	opacity: 0 !important;
-	transition: opacity 0.4s ease-in-out;
+	visibility: hidden !important;
+	transition: opacity 0.4s ease-in-out, visibility 0s linear 0.4s;
 	pointer-events: none !important;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves lyrics UI hiding behavior and standardizes visual styling.
> 
> - **Hide behavior:** When `.radiant-lyrics-ui-hidden` is active, the `header-container` (search, minimize, fullscreen) is now fully hidden with opacity/visibility transitions and disabled pointer events.
> - **Styling tweak:** Rounded corners reduced from `10px` to `5px` for common elements (`_thumbnail_`, `_imageWrapper_`, `_coverImage_`, `_overlayIconWrapperAlbum_`, `_playButton_`) across `dark-theme.css`, `light-theme.css`, `oled-friendly.css`, and `radiant-lyrics-luna/styles.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc82194a901e1ac61527839e37b47cec2977655b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->