### PR TITLE
fix(ci): allow esbuild build scripts to fix ERR_PNPM_IGNORED_BUILDS

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,10 @@
 		"rimraf": "^6.0.1",
 		"tsx": "^4.19.4",
 		"typescript": "^5.8.3"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"esbuild"
+		]
 	}
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
  - "plugins/*"
+
+onlyBuiltDependencies:
+ - esbuild


### PR DESCRIPTION
## Problem

Since pnpm v10, dependency build/postinstall scripts are blocked by default as a supply-chain security measure. The latest `[main] Release` run ([run #25985652369](https://github.com/meowarex/TidaLuna-Plugins/actions/runs/25985652369)) fails at *Install dependencies* with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.25.5
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
Error: Process completed with exit code 1.
```

`pnpm approve-builds` is interactive, so it can't be used in GitHub Actions.

## Fix

Declare `esbuild` as an allowed build dependency in **both** config locations for parity:

- **`pnpm-workspace.yaml`** — canonical location since pnpm 10.7+ (this is where `pnpm approve-builds` writes today).
- **`package.json`** under `pnpm.onlyBuiltDependencies` — legacy/back-compat path.

pnpm will pick up whichever it reads; having both means the project is forward- and backward-compatible across pnpm 10.x versions with no behavioural difference.

## Refs

- pnpm/pnpm#9102 — `approve-builds` needs a non-interactive equivalent
- pnpm/pnpm#9326 — global disable / `dangerouslyAllowAllBuilds`
- pnpm/pnpm#9399 — `--allow-build` write location fix (10.8.1)
- https://pnpm.io/next/cli/approve-builds

## Merge note

When this is merged `dev` → `main`, the merge commit on `main` already contains these files, so the triggered `[main] Release` workflow will install cleanly — no chicken-and-egg.