### PR TITLE
fix(ci): use pnpm 11 `allowBuilds` syntax and pin pnpm version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,7 @@ jobs:
 
    - name: Install pnpm 📥
      uses: pnpm/action-setup@v4
-     with:
-      version: latest
+     # Version is read from `packageManager` in package.json for reproducible builds.
 
    - name: Install Node.js 📥
      uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "@meowarex/TidalLuna-Plugins",
 	"description": "A Collection of Plugins for TidalLuna",
 	"type": "module",
+	"packageManager": "pnpm@11.1.2",
 	"scripts": {
 		"watch": "concurrently \"pnpm:build --watch\" pnpm:serve",
 		"build": "rimraf ./dist && tsx esbuild.config.ts",
@@ -18,10 +19,5 @@
 		"rimraf": "^6.0.1",
 		"tsx": "^4.19.4",
 		"typescript": "^5.8.3"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"esbuild"
-		]
 	}
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 packages:
  - "plugins/*"
 
-onlyBuiltDependencies:
- - esbuild
+# pnpm 11 renamed `onlyBuiltDependencies` (list) to `allowBuilds` (map of name -> bool).
+# This whitelists postinstall/build scripts non-interactively in CI.
+allowBuilds:
+ esbuild: true


### PR DESCRIPTION
## What happened

PR #119 added `onlyBuiltDependencies: [esbuild]` to `pnpm-workspace.yaml`, but the next `[main] Release` run ([#25992091542](https://github.com/meowarex/TidaLuna-Plugins/actions/runs/25992091542)) still failed with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.25.5
```

Root cause: `pnpm/action-setup@v4` with `version: latest` installed **pnpm 11.1.2** (`+ pnpm 11.1.2` in the log). In pnpm 11, `onlyBuiltDependencies` was **removed** and replaced by [`allowBuilds`](https://pnpm.io/next/cli/approve-builds), a map of `packageName: true|false`. The old key is silently ignored. The `pnpm.onlyBuiltDependencies` block in `package.json` also doesn't apply at the workspace level — pnpm reads workspace-level config from `pnpm-workspace.yaml` only.

## Changes

- **`pnpm-workspace.yaml`** — replace list with map:
  ```yaml
  allowBuilds:
    esbuild: true
  ```
- **`package.json`** — add `"packageManager": "pnpm@11.1.2"` so the pnpm version is reproducible (and stops silently jumping majors), and drop the now-dead `pnpm.onlyBuiltDependencies` block.
- **`.github/workflows/build.yml`** — remove `with: { version: latest }` from `pnpm/action-setup@v4`; the action picks up the version from `packageManager` automatically.

## Refs

- [pnpm Settings — `allowBuilds`, added in v10.26.0, primary in v11](https://pnpm.io/settings)
- [pnpm approve-builds CLI page](https://pnpm.io/next/cli/approve-builds)
- pnpm/pnpm#9102, pnpm/pnpm#9326

## Why this won't bite again

With `packageManager` pinned to `pnpm@11.1.2`, both local dev and CI use the exact same pnpm. Bump the pin intentionally when ready.